### PR TITLE
Increase auth validity duration in CiperStorageKeystoreRsaEcb.java fr…

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageKeystoreRsaEcb.java
@@ -225,7 +225,7 @@ public class CipherStorageKeystoreRsaEcb extends CipherStorageBase {
       .setEncryptionPaddings(PADDING_PKCS1)
       .setRandomizedEncryptionRequired(true)
       .setUserAuthenticationRequired(true)
-      .setUserAuthenticationValidityDurationSeconds(1)
+      .setUserAuthenticationValidityDurationSeconds(5)
       .setKeySize(ENCRYPTION_KEY_SIZE);
   }
 


### PR DESCRIPTION
Increase auth validity duration in CiperStorageKeystoreRsaEcb.java from 1 -> 5 seconds to possibly fix auth error on S7 Android 7.0